### PR TITLE
Fix/rtd git lfs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -28,6 +28,7 @@ python:
       extra_requirements:
         - sphinx_rtd_theme
         - numpydoc
+        - git_lfs  # hack to include images that are git LFS
     - method: setuptools
       path: .
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,12 +23,7 @@ python:
   version: 3.7
   install:
     - requirements: requirements.txt
-    - method: pip
-      path: .
-      extra_requirements:
-        - sphinx_rtd_theme
-        - numpydoc
-        - git_lfs  # hack to include images that are git LFS
+    - requirements: docs/requirements.txt
     - method: setuptools
       path: .
 

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Main features
 Install
 =======
 
-Install the package from PyPI:
+Install the package from PyPI::
 
     $ pip install tunacell
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,9 +16,57 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
+import os
+import logging
+import sys
 # sys.path.insert(0, os.path.abspath('.'))
+
+logger = logging.getLogger(__name__)
+
+DOC_SOURCES_DIR = os.path.dirname(os.path.abspath(__file__))
+logger.info("Documentation folder: {}".format(DOC_SOURCES_DIR))
+PROJECT_ROOT_DIR = os.path.dirname(DOC_SOURCES_DIR)
+logger.info("Project folder: {}".format(PROJECT_ROOT_DIR))
+
+# insert
+sys.path.insert(0, DOC_SOURCES_DIR)
+
+# this is quite dirty approach but we're not working at NASA and nobody can die
+# because of that. Am I right?
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+if on_rtd:
+
+    render_examples = False
+
+    # hack for lacking git-lfs support on rtd
+    import git_lfs
+    try:
+        from urllib.error import HTTPError
+    except ImportError:
+        from urllib2 import HTTPError
+
+    _fetch_urls = git_lfs.fetch_urls
+
+    def _patched_fetch_urls(lfs_url, oid_list):
+        """Hack git_lfs library that sometimes makes too big requests"""
+        objects = []
+
+        try:
+            objects.extend(_fetch_urls(lfs_url, oid_list))
+        except HTTPError as err:
+            if err.code != 413:
+                raise
+            logger.error("LFS: request entity too large, splitting in half")
+            objects.extend(_patched_fetch_urls(lfs_url, oid_list[:len(oid_list) // 2]))
+            objects.extend(_patched_fetch_urls(lfs_url, oid_list[len(oid_list) // 2:]))
+
+        return objects
+
+    git_lfs.fetch_urls = _patched_fetch_urls
+    git_lfs.fetch(PROJECT_ROOT_DIR)
+
+else:
+    render_examples = True
 
 
 # -- General configuration ------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,38 +35,9 @@ sys.path.insert(0, DOC_SOURCES_DIR)
 # because of that. Am I right?
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if on_rtd:
-
-    render_examples = False
-
     # hack for lacking git-lfs support on rtd
     import git_lfs
-    try:
-        from urllib.error import HTTPError
-    except ImportError:
-        from urllib2 import HTTPError
-
-    _fetch_urls = git_lfs.fetch_urls
-
-    def _patched_fetch_urls(lfs_url, oid_list):
-        """Hack git_lfs library that sometimes makes too big requests"""
-        objects = []
-
-        try:
-            objects.extend(_fetch_urls(lfs_url, oid_list))
-        except HTTPError as err:
-            if err.code != 413:
-                raise
-            logger.error("LFS: request entity too large, splitting in half")
-            objects.extend(_patched_fetch_urls(lfs_url, oid_list[:len(oid_list) // 2]))
-            objects.extend(_patched_fetch_urls(lfs_url, oid_list[len(oid_list) // 2:]))
-
-        return objects
-
-    git_lfs.fetch_urls = _patched_fetch_urls
     git_lfs.fetch(PROJECT_ROOT_DIR)
-
-else:
-    render_examples = True
 
 
 # -- General configuration ------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+numpydoc
+sphinx_rtd_theme
+git_lfs

--- a/docs/users/plotting-samples.rst
+++ b/docs/users/plotting-samples.rst
@@ -44,7 +44,7 @@ plotting small samples in few test cases.
 Setting up samples and observables
 -----------------------------------
 
-For plotting demonstration, 
+For plotting demonstration,
 we will create a numerically simulated experiment, where the dynamics
 is sampled on a time interval short enough for the colonies to be of reasonable
 size. Call from a terminal::
@@ -56,12 +56,12 @@ In a Python script/shell, we load data with the usual::
     from tunacell import Experiment, Parser, Observable, FilterSet
     from tunacell.filters.cells import FilterCellIDparity
     from tunacell.plotting.samples import SamplePlot
-    
+
     exp = Experiment('~/tmptunacell/simushort')
     parser = Parser(exp)
     np.random.seed(seed=951)  # uncomment this line to match samples/plots below
     parser.add_sample(10)
-    
+
     # define a condition
     even = FilterCellIDparity('even')
     condition = FilterSet(filtercell=even)
@@ -69,7 +69,7 @@ In a Python script/shell, we load data with the usual::
     # define observable
     length = Observable(name='length', raw='exp_ou_int')
     ou = Observable(name='growth-rate', raw='ou')
-    
+
 We have defined two observables and one condition used as a toy example.
 With these preliminary lines, we are ready to plot timeseries. The main object
 to call is :class:`SamplePlot`, which accepts the following parameters:
@@ -133,6 +133,7 @@ The figure is stored as the :attr:`fig` attribute of :code:`colplt`::
 This kind of plot should be produced:
 
 .. figure:: /images/colony0-plot.png
+   :width: 60%
 
    Timeseries of length vs time for one colony, default settings.
 
@@ -163,6 +164,7 @@ the :func:`repr` call.
 Now the :attr:`fig` attribute should store the following result:
 
 .. figure:: /images/colony0-even-plot.png
+   :width: 60%
 
    Timeseries of length vs time for one colony. Plain markers are used for
    samples that verify the condition (cell identifier is even), empty markers
@@ -183,6 +185,7 @@ Changing cell colour
     colplt.make_plot(length, report_condition=repr(condition), change_cell_color=True)
 
 .. figure:: /images/colony0-even-cell-color-plot.png
+   :width: 60%
 
   Colour is changed for each cell, and assigned with respect to the generation
   index of the cell in the colony. This allows to investigate how generations
@@ -196,6 +199,7 @@ Changing lineage colour
     colplt.make_plot(length, report_condition=repr(condition), change_lineage_color=True)
 
 .. figure:: /images/colony0-even-lineage-color-plot.png
+   :width: 60%
 
   Colour is changed for each lineage, *i.e* each row in this colony plot.
 
@@ -222,6 +226,7 @@ For example, if we superimpose at most 3 lineages::
                  superimpose=3)
 
 .. figure:: /images/colony0-even-super3-plot.png
+   :width: 60%
 
    Superimposition of at most 3 lineages with :code:`superimpose=3`. Once
    :code:`superimpose` is different from ``'none'`` (or 1), the vertical lines
@@ -243,6 +248,7 @@ colonies in the same plot, that can be given as an iterable over colonies::
 Here we iterated over colonies from the samples defined in ``parser.samples``.
 
 .. figure:: /images/colonies-even-plot.png
+   :width: 60%
 
    First two colonies from ``parser.samples``, with changing colony colour
    option.
@@ -267,6 +273,7 @@ files::
 
 
 .. figure:: /images/colonies5-ou-even-plot.png
+   :width: 60%
 
    Two lineages are superimposed on each row. Colour is changed for each new
    colony.
@@ -280,6 +287,7 @@ to distinguish better individual timeseries::
                     alpha=.6)
 
 .. figure:: /images/lineages-from-colonies5-plot.png
+   :width: 60%
 
    Lineages from the 5 colonies superimposed on a single row plot.
 
@@ -297,6 +305,7 @@ or an iterable over lineages as argument of the plotting environment::
 
 
 .. figure:: /images/lineages10-plot.png
+   :width: 60%
 
    10 lineages from an iterator on a single row plot.
 
@@ -323,6 +332,7 @@ values::
                     ref_mean=ref_mean, ref_var=ref_var)
 
 .. figure:: /images/lineages10-with-ref-plot.png
+   :width: 60%
 
    Timeseries from lineages are reported together with theoretical mean value
    (dash-dotted horizontal line) +/- one standard deviation (dotted lines).
@@ -340,6 +350,7 @@ is useful when no theoretical values exist (most of the time)::
                 data_statistics=True)
 
 .. figure:: /images/lineages10-with-stats-plot.png
+   :width: 60%
 
    Data statistics have been added: grey line shows the estimated mean value
    and shadows show +/- one estimated standard deviation. Note that these

--- a/docs/users/statistics.rst
+++ b/docs/users/statistics.rst
@@ -108,7 +108,7 @@ In ``tuna``, there is a special procedure to estimate :math:`\tilde{a}` which is
 to use the lineage decomposition to generate time series, and then for a given
 time interval :math:`u`, we collect all couple of points
 :math:`(t_i, t_j)` such that :math:`u = t_i - t_j`, and perform the average
-over all these samples. 
+over all these samples.
 
 We can extend such a computation to two observables :math:`x(t)` and
 :math:`y(t)`. The relevant quantity is the cross-correlation function
@@ -210,7 +210,7 @@ As the master is always defined, one can alternatively use the attribute::
     result = univ.master
 
 
-Inspecting univariate results 
+Inspecting univariate results
 ''''''''''''''''''''''''''''''''''''
 
 The objects ``result`` and ``result_conditioned`` are instances of the
@@ -334,6 +334,7 @@ The first figure, stored in ``fig1``, looks like:
 .. _fig-one-point:
 
 .. figure:: /images/plot_onepoint_exact-growth-rate_ALL.png
+   :width: 60%
 
    Plot of one-point functions computed by ``tuna``. The first row shows the
    sample counts vs. time, :math:`s^{(1)}_i` vs. :math:`t_i`. The middle row
@@ -356,6 +357,7 @@ The second figure, stored in ``fig2``, looks like so:
 .. _fig-two-point:
 
 .. figure:: /images/plot_twopoints_exact-growth-rate_ALL.png
+   :width: 60%
 
    Plot of two-point functions. Three times of reference are chosen to display
    the associated functions. Top row shows the sample counts, *i.e.* the
@@ -364,7 +366,7 @@ The second figure, stored in ``fig2``, looks like so:
    :math:`a(t_{\mathrm{ref}}, t)/\sigma^2(t_{\mathrm{ref}})`.
    The bottom row show the translated functions
    :math:`a(t_{\mathrm{ref}}, t-t_{\mathrm{ref}})/\sigma^2(t_{\mathrm{ref}})`.
-   One can guess that they peak at :math:`t-t_{\mathrm{ref}} \approx 0`, 
+   One can guess that they peak at :math:`t-t_{\mathrm{ref}} \approx 0`,
    though decay on both sides are quite irregular compared to the expected
    behaviour due to the low sample size.
 
@@ -450,6 +452,7 @@ instance. The second parameter displays an exponential decay (to compare with
 data).
 
 .. figure:: /images/plot_stationary_exact-growth-rate_ALL.png
+   :width: 60%
 
    Plot of stationary autocorrelation function. Top row is the number of
    samples, *i.e.* the number of (disjoint) segments of size :math:`\Delta t`
@@ -499,7 +502,7 @@ text files before. Hence a convenient way to work is::
         print('Launching computation')
         univ = compute_univariate(exp, ou, cset=[condition, ])
         univ.export_text()
-    
+
 
 Bivariate analysis: cross-correlations
 --------------------------------------------------------
@@ -593,6 +596,7 @@ autocorrelation functions::
 which should plot something like:
 
 .. figure:: /images/plot_stationary_exact-growth-rate---approx-growth-rate_ALL.png
+   :width: 60%
 
    Plot of the stationary cross-correlation function of the Ornstein-Uhlenbeck
    process with the local growth rate estimate using the exponential of the
@@ -608,6 +612,7 @@ If one performs a similar analysis with the two cell-cycle observables,
 for example:
 
 .. figure:: /images/plot_stationary_average-growth-rate---division-size_ALL.png
+   :width: 60%
 
    Plot of the stationary cross-correlation function of the cell-cycle average
    growth rate with the cell length at division, with respect to the number of


### PR DESCRIPTION
I've used a hack to download image files that are git-lfs'd on the repo (ReadTheDocs does not support Git LFS to this day).

See https://github.com/readthedocs/readthedocs.org/issues/1846#issuecomment-257704349 and https://github.com/readthedocs/readthedocs.org/issues/1846#issuecomment-278286430 (this workaround uses the git_lfs python module available on the Index).

See also https://github.com/readthedocs/readthedocs.org/issues/1846#issuecomment-477184259 for another warkaround proposed by a RTD contributor.